### PR TITLE
Feat/issue7 (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# gconsole ChangeLogs
+
+## gconsole v0.1.0
+* [feat] implement the basic feature of printer package
+  
+## gconsole v0.2.0
+* [feat] Adding read capability from stdin

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,1 @@
+# Documents under implementation

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2022-NOW Ornelio Chauque (chauque.ornelio@gmail,com)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/MAINTAINER
+++ b/MAINTAINER
@@ -1,0 +1,2 @@
+Maintainers:
+- Ornelio-Chauque

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -1,27 +1,28 @@
 package printer
 
 import (
+	"fmt"
 	"os"
 )
 
 // Will print the content of string to the stdout
-func Print(s string) string {
+func Print(s string) (string, error) {
 	_, err := writeStdout([]byte(s))
 	if err != nil {
-		panic(" Problem writing to stdout")
+		return "", fmt.Errorf("on printer.Print: %w", err)
 	}
-	return s
+	return s, nil
 }
 
 // will print the content of the string to stdou and then LF
-func Println(s string) string {
+func Println(s string) (string, error) {
 	newString := s + "\n"
 	_, err := writeStdout([]byte(newString))
 	if err != nil {
-		panic(" Problem writing to stdout")
+		return "", fmt.Errorf("on printer.Println: %w", err)
 	}
 
-	return s
+	return s, nil
 }
 
 func Printf(format string, args ...string) {
@@ -29,14 +30,19 @@ func Printf(format string, args ...string) {
 }
 
 // write the content to the specified file name
-func WriteTo(filename string, data []byte, mode os.FileMode) {
+func WriteTo(filename string, data []byte, mode os.FileMode) error {
 
-	f := processFile(filename, mode)
-	defer f.Close()
-	_, err := write(f, data)
-	if err != nil {
-		panic(" we find issue writing to this file")
+	f, err := processFile(filename, mode)
+	if err != nil{
+		return err
 	}
+	defer f.Close()
+	
+	_, err = write(f, data)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Makes gconsole.printer a io.Writer
@@ -59,11 +65,11 @@ func write(f *os.File, data []byte) (int, error) {
 
 // Helper function which make a syscal to open a file with read and write mode if exist
 //if don't exist creates the file
-func processFile(filename string, mode os.FileMode) *os.File {
+func processFile(filename string, mode os.FileMode) (*os.File, error) {
 
 	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE, mode)
 	if err != nil {
-		panic(" expecting filename not filepath") //TODO: impprove error mesage
+		return nil, fmt.Errorf("in printer.processprocessFile: %w", err)
 	}
-	return f
+	return f, nil
 }

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestPrintStringToStdout(t *testing.T) {
 	s := "Hello Word"
-	result := Print(s)
+	result, _ := Print(s)
 
 	if result != s {
 		t.Errorf("expect %s, and found %s", s, result)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -1,17 +1,66 @@
 package scanner
 
 import (
+	"fmt"
 	"os"
+	"strings"
 )
-
+const (
+	BUFFER_SIZE = 256// set a fixed buffer size, to allow better use of memory
+)
 // Get the user input from console and retun as s string
-func Get() string {
+func Get() (string, error) {
 	s := os.Stdin
-	buff := make([]byte, 128)
-	_, err := s.Read(buff)
+	buff := make([]byte, BUFFER_SIZE)
 	defer s.Close()
-	if err != nil {
-		panic(" something unexpected happens, can't read from stdio")
+    var err error;
+	var inputResultBuilder strings.Builder
+
+	for n:=0; err == nil;{
+		
+		n,err = s.Read(buff)
+		if err != nil {
+			return "", fmt.Errorf("on Get: %w", err)
+		}
+		inputResultBuilder.Write(buff[:n])
+		
+		//When the number of byte written to buff (c) is less than the overall buff capacity (BUFFER_SIZE),
+		// means no more bytes reamins to be read, so break the loop
+		if n < BUFFER_SIZE{
+			break
+		}
+
+
 	}
-	return string(buff)
+	
+	return inputResultBuilder.String(), nil
 }
+
+//GetBytes return the  slice of byte representation of content read from Stdin
+func GetBytes() ([]byte, error) {
+	s := os.Stdin
+	buff := make([]byte, BUFFER_SIZE)
+	defer s.Close()
+    var err error;
+	inputResult := make([]byte, BUFFER_SIZE)
+
+	for n:=0; err == nil;{
+		
+		n,err = s.Read(buff)
+		if err != nil {
+			return nil, fmt.Errorf("on GetBytes: %w", err)
+		}
+	
+		inputResult = append(inputResult, buff...)
+		//When the number of byte written to buff (c) is less than the overall buff capacity (BUFFER_SIZE),
+		// means no more bytes reamins to be read, so break the loop
+		if n < BUFFER_SIZE{
+			break
+		}
+
+
+	}
+	
+	return inputResult, nil
+}
+

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -9,3 +9,7 @@ func TestHello (t *testing.T){
 		t.Error("error")
 	}
 }
+
+func TestGet (t *testing.T){
+	
+}


### PR DESCRIPTION
* fix: allow scanner package to accept any amount of byte as input from stdin

* fix: remove unreachable break(after panic)

* feat: add method to get byte representation of the string received from stdin

* refactor: return the error to the caller instead of rise a panic

* refactor: add error as return to all necessary func to allow the caller to handle the error

* fix: add license in which the project is based on

* chore: add maintainers file.

* chore: add change logs data

Co-authored-by: Ornelio Chauque <ornelio.chauque@vm.co.mz>